### PR TITLE
Add monaco again

### DIFF
--- a/packages/corewar-app/src/features/files/code-editor.js
+++ b/packages/corewar-app/src/features/files/code-editor.js
@@ -1,96 +1,9 @@
-import React, { useState, useRef, useEffect } from 'react'
+import React, { useEffect } from 'react'
 import { useDispatch } from 'react-redux'
 import { parse } from './actions'
 import FileStatusBar from './file-status-bar'
 import { ControlledEditor, monaco } from '@monaco-editor/react'
-
-const redcodeDefinition = {
-  // Set defaultToken to invalid to see what you do not tokenize yet
-  defaultToken: 'invalid',
-
-  opcodes: [
-    'dat',
-    'mov',
-    'add',
-    'sub',
-    'mul',
-    'div',
-    'mod',
-    'jmp',
-    'jmz',
-    'jmn',
-    'djn',
-    'cmp',
-    'slt',
-    'spl',
-    'seq',
-    'sne',
-    'nop',
-    'DAT',
-    'MOV',
-    'ADD',
-    'SUB',
-    'MUL',
-    'DIV',
-    'MOD',
-    'JMP',
-    'JMZ',
-    'JMN',
-    'DJN',
-    'CMP',
-    'SLT',
-    'SPL',
-    'SEQ',
-    'SNE',
-    'NOP'
-  ],
-
-  preprocessor: ['equ', 'end', 'org', 'for', 'rof', 'EQU', 'END', 'ORG', 'FOR', 'ROF'],
-
-  addressingModes: ['#', '$', '@', '<', '>', '{', '}', '*'],
-
-  // The main tokenizer for our languages
-  tokenizer: {
-    root: [
-      // identifiers and keywords
-      [
-        /[a-zA-Z_$][\w$]*/,
-        {
-          cases: {
-            '@opcodes': 'keyword',
-            '@preprocessor': 'keyword',
-            '@default': 'identifier'
-          }
-        }
-      ],
-
-      // meta
-      [/;(name|author|strategy).*$/, 'meta'],
-      [/;(redcode|redcode-.*)$/, 'meta'],
-      [/;assert .+$/, 'meta'],
-
-      // whitespace
-      { include: '@whitespace' },
-
-      // preprocessor maths <- THIS IS WRONG TROUbLE FINDING * (is it preprocessor?)
-      [/(?<=equ.+)(\+|\-|\*|\/)/][
-        // delimiters
-        (/[:,.]/, 'delimiter')
-      ],
-
-      // numbers
-      [/[0-9]+/, 'number'],
-
-      // addressing mode
-      [/(#|\$|@|<|>|{|}|\*)/, 'type']
-    ],
-
-    whitespace: [
-      [/[ \t\r\n]+/, 'white'],
-      [/;.*$/, 'comment']
-    ]
-  }
-}
+import { redcodeLanguageDefinition, redcodeTheme } from '../../services/monaco'
 
 const options = {
   minimap: {
@@ -100,103 +13,17 @@ const options = {
 
 const CodeEditor = ({ currentFile }) => {
   const dispatch = useDispatch()
-  const [isEditorReady, setIsEditorReady] = useState(false)
-  //const [value, setValue] = useState(currentFile ? currentFile.source : '')
-  const valueGetter = useRef()
 
   useEffect(() => {
     monaco
       .init()
       .then(monaco => {
-        /* here is the instance of monaco, so you can use the `monaco.languages` or whatever you want */
         monaco.languages.register({ id: 'redcode' })
-        monaco.languages.setMonarchTokensProvider(
-          'redcode', // The main tokenizer for our languages
-          {
-            defaultToken: '',
-            tokenPostfix: '.red',
-            ignoreCase: true,
-            opcodes: [
-              'DAT',
-              'MOV',
-              'ADD',
-              'SUB',
-              'MUL',
-              'DIV',
-              'MOD',
-              'JMP',
-              'JMZ',
-              'JMN',
-              'DJN',
-              'CMP',
-              'SLT',
-              'SPL',
-              'SEQ',
-              'SNE',
-              'NOP'
-            ],
-            preprocessor: ['EQU', 'END', 'ORG', 'FOR', 'ROF'],
-            addressingModes: ['#', '$', '@', '<', '>', '{', '}', '*'],
-            tokenizer: {
-              root: [
-                [
-                  /[a-zA-Z_$][\w$]*/,
-                  {
-                    cases: {
-                      '@opcodes': 'keyword',
-                      '@preprocessor': 'keyword',
-                      '@default': 'identifier'
-                    }
-                  }
-                ],
-
-                // meta
-                [/;(name|author|strategy).*$/, 'meta'],
-                [/;(redcode|redcode-.*)$/, 'meta'],
-                [/;assert .+$/, 'meta'],
-
-                // whitespace
-                { include: '@whitespace' },
-
-                // preprocessor maths <- THIS IS WRONG TROUbLE FINDING * (is it preprocessor?)
-                // [/(?<=equ.+)(\+|\-|\*|\/)/][
-                //   // delimiters
-                //   (/[:,.]/, 'delimiter')
-                // ],
-
-                // numbers
-                [/[0-9]+/, 'number'],
-
-                // addressing mode
-                [/(#|\$|@|<|>|{|}|\*)/, 'type']
-              ],
-              whitespace: [
-                [/[ \t\r\n]+/, 'white'],
-                [/;.*$/, 'comment']
-              ]
-            }
-          }
-        )
-        monaco.editor.defineTheme('redcode', {
-          base: 'vs-dark',
-          inherit: true,
-          rules: [
-            // { token: 'custom-info', foreground: '808080' },
-            // { token: 'custom-error', foreground: 'ff0000', fontStyle: 'bold' },
-          ],
-          colors: {
-            'editor.background': '#353E4A',
-            'editor.lineHighlightBackground': '#20252C'
-          }
-        })
+        monaco.languages.setMonarchTokensProvider('redcode', redcodeLanguageDefinition)
+        monaco.editor.defineTheme('redcode', redcodeTheme)
       })
       .catch(error => console.error('An error occurred during initialization of Monaco: ', error))
   })
-
-  function handleEditorDidMount(_valueGetter) {
-    setIsEditorReady(true)
-    valueGetter.current = _valueGetter
-  }
 
   return (
     <section className="flex flex-col w-full p-2 rounded-lg rounded-tl-none bg-gray-700 text-gray-100">
@@ -205,7 +32,6 @@ const CodeEditor = ({ currentFile }) => {
         language="redcode"
         theme="redcode"
         value={currentFile ? currentFile.source : ''}
-        editorDidMount={handleEditorDidMount}
         onChange={(event, value) => dispatch(parse(value))}
         options={options}
       />

--- a/packages/corewar-app/src/features/files/code-editor.js
+++ b/packages/corewar-app/src/features/files/code-editor.js
@@ -101,7 +101,7 @@ const options = {
 const CodeEditor = ({ currentFile }) => {
   const dispatch = useDispatch()
   const [isEditorReady, setIsEditorReady] = useState(false)
-  const [value, setValue] = useState(currentFile ? currentFile.source : '')
+  //const [value, setValue] = useState(currentFile ? currentFile.source : '')
   const valueGetter = useRef()
 
   useEffect(() => {
@@ -186,7 +186,7 @@ const CodeEditor = ({ currentFile }) => {
           ],
           colors: {
             'editor.background': '#353E4A',
-            'editor.lineHighlightBackground': '#556477'
+            'editor.lineHighlightBackground': '#20252C'
           }
         })
       })
@@ -196,10 +196,6 @@ const CodeEditor = ({ currentFile }) => {
   function handleEditorDidMount(_valueGetter) {
     setIsEditorReady(true)
     valueGetter.current = _valueGetter
-  }
-
-  function handleShowValue() {
-    alert(valueGetter.current())
   }
 
   return (
@@ -213,15 +209,6 @@ const CodeEditor = ({ currentFile }) => {
         onChange={(event, value) => dispatch(parse(value))}
         options={options}
       />
-      {/* <textarea
-        className="flex self-stretch h-full bg-transparent font-code resize-none overflow-auto whitespace-pre-wrap mx-4"
-        auto-complete="off"
-        auto-correct="off"
-        auto-capitalize="off"
-        spellCheck="false"
-        value={currentFile ? currentFile.source : ''}
-        onChange={e => dispatch(parse(e.target.value))}
-      ></textarea> */}
     </section>
   )
 }

--- a/packages/corewar-app/src/features/files/code-editor.js
+++ b/packages/corewar-app/src/features/files/code-editor.js
@@ -1,41 +1,228 @@
-import React from 'react'
+import React, { useState, useRef, useEffect } from 'react'
 import { useDispatch } from 'react-redux'
 import { parse } from './actions'
 import FileStatusBar from './file-status-bar'
-//import Editor from '@monaco-editor/react'
+import { ControlledEditor, monaco } from '@monaco-editor/react'
 
-// const options = {
-//   minimap: {
-//     enabled: false
-//   }
-// }
+const redcodeDefinition = {
+  // Set defaultToken to invalid to see what you do not tokenize yet
+  defaultToken: 'invalid',
+
+  opcodes: [
+    'dat',
+    'mov',
+    'add',
+    'sub',
+    'mul',
+    'div',
+    'mod',
+    'jmp',
+    'jmz',
+    'jmn',
+    'djn',
+    'cmp',
+    'slt',
+    'spl',
+    'seq',
+    'sne',
+    'nop',
+    'DAT',
+    'MOV',
+    'ADD',
+    'SUB',
+    'MUL',
+    'DIV',
+    'MOD',
+    'JMP',
+    'JMZ',
+    'JMN',
+    'DJN',
+    'CMP',
+    'SLT',
+    'SPL',
+    'SEQ',
+    'SNE',
+    'NOP'
+  ],
+
+  preprocessor: ['equ', 'end', 'org', 'for', 'rof', 'EQU', 'END', 'ORG', 'FOR', 'ROF'],
+
+  addressingModes: ['#', '$', '@', '<', '>', '{', '}', '*'],
+
+  // The main tokenizer for our languages
+  tokenizer: {
+    root: [
+      // identifiers and keywords
+      [
+        /[a-zA-Z_$][\w$]*/,
+        {
+          cases: {
+            '@opcodes': 'keyword',
+            '@preprocessor': 'keyword',
+            '@default': 'identifier'
+          }
+        }
+      ],
+
+      // meta
+      [/;(name|author|strategy).*$/, 'meta'],
+      [/;(redcode|redcode-.*)$/, 'meta'],
+      [/;assert .+$/, 'meta'],
+
+      // whitespace
+      { include: '@whitespace' },
+
+      // preprocessor maths <- THIS IS WRONG TROUbLE FINDING * (is it preprocessor?)
+      [/(?<=equ.+)(\+|\-|\*|\/)/][
+        // delimiters
+        (/[:,.]/, 'delimiter')
+      ],
+
+      // numbers
+      [/[0-9]+/, 'number'],
+
+      // addressing mode
+      [/(#|\$|@|<|>|{|}|\*)/, 'type']
+    ],
+
+    whitespace: [
+      [/[ \t\r\n]+/, 'white'],
+      [/;.*$/, 'comment']
+    ]
+  }
+}
+
+const options = {
+  minimap: {
+    enabled: false
+  }
+}
 
 const CodeEditor = ({ currentFile }) => {
   const dispatch = useDispatch()
-  // const [isEditorReady, setIsEditorReady] = useState(false)
-  // const valueGetter = useRef()
+  const [isEditorReady, setIsEditorReady] = useState(false)
+  const [value, setValue] = useState(currentFile ? currentFile.source : '')
+  const valueGetter = useRef()
 
-  // function handleEditorDidMount(_valueGetter) {
-  //   setIsEditorReady(true)
-  //   valueGetter.current = _valueGetter
-  // }
+  useEffect(() => {
+    monaco
+      .init()
+      .then(monaco => {
+        /* here is the instance of monaco, so you can use the `monaco.languages` or whatever you want */
+        monaco.languages.register({ id: 'redcode' })
+        monaco.languages.setMonarchTokensProvider(
+          'redcode', // The main tokenizer for our languages
+          {
+            defaultToken: '',
+            tokenPostfix: '.red',
+            ignoreCase: true,
+            opcodes: [
+              'DAT',
+              'MOV',
+              'ADD',
+              'SUB',
+              'MUL',
+              'DIV',
+              'MOD',
+              'JMP',
+              'JMZ',
+              'JMN',
+              'DJN',
+              'CMP',
+              'SLT',
+              'SPL',
+              'SEQ',
+              'SNE',
+              'NOP'
+            ],
+            preprocessor: ['EQU', 'END', 'ORG', 'FOR', 'ROF'],
+            addressingModes: ['#', '$', '@', '<', '>', '{', '}', '*'],
+            tokenizer: {
+              root: [
+                [
+                  /[a-zA-Z_$][\w$]*/,
+                  {
+                    cases: {
+                      '@opcodes': 'keyword',
+                      '@preprocessor': 'keyword',
+                      '@default': 'identifier'
+                    }
+                  }
+                ],
 
-  // function handleShowValue() {
-  //   alert(valueGetter.current())
-  // }
+                // meta
+                [/;(name|author|strategy).*$/, 'meta'],
+                [/;(redcode|redcode-.*)$/, 'meta'],
+                [/;assert .+$/, 'meta'],
+
+                // whitespace
+                { include: '@whitespace' },
+
+                // preprocessor maths <- THIS IS WRONG TROUbLE FINDING * (is it preprocessor?)
+                // [/(?<=equ.+)(\+|\-|\*|\/)/][
+                //   // delimiters
+                //   (/[:,.]/, 'delimiter')
+                // ],
+
+                // numbers
+                [/[0-9]+/, 'number'],
+
+                // addressing mode
+                [/(#|\$|@|<|>|{|}|\*)/, 'type']
+              ],
+              whitespace: [
+                [/[ \t\r\n]+/, 'white'],
+                [/;.*$/, 'comment']
+              ]
+            }
+          }
+        )
+        // monaco.languages.registerDocumentRangeFormattingEditProvider(...)
+        // monaco.languages.registerOnTypeFormattingEditProvider('redcode', redcodeDefinition)
+        // monaco.editor.defineTheme('redcode', {
+        //   base: 'vs-dark',
+        //   inherit: false,
+        //   rules: [
+        //     { token: '', foreground: 'EEF2F7', background: '353E4A' },
+        //     { token: 'custom-info', foreground: '808080' },
+        //     { token: 'custom-error', foreground: 'ff0000', fontStyle: 'bold' },
+        //     { token: 'custom-notice', foreground: 'FFA500' },
+        //     { token: 'custom-date', foreground: '008800' }
+        //   ],
+        //   colors: {
+        //     editorBackground: '#353E4A',
+        //     editorForeground: '#353E4A',
+        //     editorInactiveSelection: '#353E4A',
+        //     editorIndentGuides: '#353E4A',
+        //     editorActiveIndentGuides: '#353E4A',
+        //     editorSelectionHighlight: '#353E4A'
+        //   }
+        // })
+      })
+      .catch(error => console.error('An error occurred during initialization of Monaco: ', error))
+  })
+
+  function handleEditorDidMount(_valueGetter) {
+    setIsEditorReady(true)
+    valueGetter.current = _valueGetter
+  }
+
+  function handleShowValue() {
+    alert(valueGetter.current())
+  }
 
   return (
     <section className="flex flex-col w-full p-2 rounded-lg rounded-tl-none bg-gray-700 text-gray-100">
       <FileStatusBar />
-      {/* <Editor
-        height="100%"
-        language="javascript"
-        theme="dark"
-        value={'// write your code here'}
+      <ControlledEditor
+        language="redcode"
+        theme="vs-dark"
+        value={currentFile ? currentFile.source : ''}
         editorDidMount={handleEditorDidMount}
+        onChange={(event, value) => dispatch(parse(value))}
         options={options}
-      /> */}
-      <textarea
+      />
+      {/* <textarea
         className="flex self-stretch h-full bg-transparent font-code resize-none overflow-auto whitespace-pre-wrap mx-4"
         auto-complete="off"
         auto-correct="off"
@@ -43,7 +230,7 @@ const CodeEditor = ({ currentFile }) => {
         spellCheck="false"
         value={currentFile ? currentFile.source : ''}
         onChange={e => dispatch(parse(e.target.value))}
-      ></textarea>
+      ></textarea> */}
     </section>
   )
 }

--- a/packages/corewar-app/src/features/files/code-editor.js
+++ b/packages/corewar-app/src/features/files/code-editor.js
@@ -177,27 +177,18 @@ const CodeEditor = ({ currentFile }) => {
             }
           }
         )
-        // monaco.languages.registerDocumentRangeFormattingEditProvider(...)
-        // monaco.languages.registerOnTypeFormattingEditProvider('redcode', redcodeDefinition)
-        // monaco.editor.defineTheme('redcode', {
-        //   base: 'vs-dark',
-        //   inherit: false,
-        //   rules: [
-        //     { token: '', foreground: 'EEF2F7', background: '353E4A' },
-        //     { token: 'custom-info', foreground: '808080' },
-        //     { token: 'custom-error', foreground: 'ff0000', fontStyle: 'bold' },
-        //     { token: 'custom-notice', foreground: 'FFA500' },
-        //     { token: 'custom-date', foreground: '008800' }
-        //   ],
-        //   colors: {
-        //     editorBackground: '#353E4A',
-        //     editorForeground: '#353E4A',
-        //     editorInactiveSelection: '#353E4A',
-        //     editorIndentGuides: '#353E4A',
-        //     editorActiveIndentGuides: '#353E4A',
-        //     editorSelectionHighlight: '#353E4A'
-        //   }
-        // })
+        monaco.editor.defineTheme('redcode', {
+          base: 'vs-dark',
+          inherit: true,
+          rules: [
+            // { token: 'custom-info', foreground: '808080' },
+            // { token: 'custom-error', foreground: 'ff0000', fontStyle: 'bold' },
+          ],
+          colors: {
+            'editor.background': '#353E4A',
+            'editor.lineHighlightBackground': '#556477'
+          }
+        })
       })
       .catch(error => console.error('An error occurred during initialization of Monaco: ', error))
   })
@@ -216,7 +207,7 @@ const CodeEditor = ({ currentFile }) => {
       <FileStatusBar />
       <ControlledEditor
         language="redcode"
-        theme="vs-dark"
+        theme="redcode"
         value={currentFile ? currentFile.source : ''}
         editorDidMount={handleEditorDidMount}
         onChange={(event, value) => dispatch(parse(value))}

--- a/packages/corewar-app/src/features/files/state/warrior-library.js
+++ b/packages/corewar-app/src/features/files/state/warrior-library.js
@@ -2,64 +2,63 @@ export const warriorLibrary = [
   {
     name: `Looping Paper`,
     source: `;name Looping Paper
-      step   equ 5620
-  
-      paper   mov    #5,       #0
-      copy    mov    <paper,   {dest
-              jmn    copy,     paper
-              spl    >paper,   {-1277
-      dest    jmz    step,     *0`
+step   equ 5620
+
+paper   mov    #5,       #0
+copy    mov    <paper,   {dest
+        jmn    copy,     paper
+        spl    >paper,   {-1277
+dest    jmz    step,     *0`
   },
   {
     name: `Blur Scanner`,
     source: `;name Blur Scanner
-      step   equ 4884
-  
-      wptr    mov.b  scan,       #0
-      scan    add    #step,      #step
-      gate    mov    *bomb,      >wptr
-              jmz.f  scan,       @scan
-              jmn    wptr,       *wptr
-  
-      bomb    spl    0,          0
-      clear   mov    dbmb,       >gate
-              djn.f  clear,      >gate
-      dbmb    dat    <2667,      2-gate`
+step   equ 4884
+
+wptr    mov.b  scan,       #0
+scan    add    #step,      #step
+gate    mov    *bomb,      >wptr
+        jmz.f  scan,       @scan
+        jmn    wptr,       *wptr
+
+bomb    spl    0,          0
+clear   mov    dbmb,       >gate
+        djn.f  clear,      >gate
+dbmb    dat    <2667,      2-gate`
   },
   {
     name: `Transposition Stone`,
     source: `;name Transposition Stone
-      step   equ 1185           ; mod 5
-  
-      inc     spl    #-step,   <step
-      stone   mov    >step,    1-step
-              sub    inc,      stone
-              djn.f  stone,    <5555`
+step   equ 1185           ; mod 5
+
+inc     spl    #-step,   <step
+stone   mov    >step,    1-step
+        sub    inc,      stone
+        djn.f  stone,    <5555`
   },
   {
     name: `Self-Vamping Vampire`,
     source: `;name Self-Vamping Vampire
-      step   equ -715           ; mod 5
-  
-      inc     spl    #step,     <-step
-      vampire mov    fang,      @fang   ; fang dropped here
-              sub    inc,       fang
-              djn.f  vampire,   *fang
-  
-              for    5
-              dat    0,0
-              rof
-  
-      trap    mov    bomb+1,    <vampire-9
-              spl    trap
-              jmp    trap+1
-      bomb    dat    <5334,     <2667
-  
-              for    3
-              dat    0,0
-              rof
-  
-      fang    jmp    trap-vampire-step,<vampire+step
-      `
+step   equ -715           ; mod 5
+
+inc     spl    #step,     <-step
+vampire mov    fang,      @fang   ; fang dropped here
+        sub    inc,       fang
+        djn.f  vampire,   *fang
+
+        for    5
+        dat    0,0
+        rof
+
+trap    mov    bomb+1,    <vampire-9
+        spl    trap
+        jmp    trap+1
+bomb    dat    <5334,     <2667
+
+        for    3
+        dat    0,0
+        rof
+
+fang    jmp    trap-vampire-step,<vampire+step`
   }
 ]

--- a/packages/corewar-app/src/services/monaco.js
+++ b/packages/corewar-app/src/services/monaco.js
@@ -1,0 +1,77 @@
+export const redcodeLanguageDefinition = {
+  defaultToken: '',
+  tokenPostfix: '.red',
+  ignoreCase: true,
+  opcodes: [
+    'DAT',
+    'MOV',
+    'ADD',
+    'SUB',
+    'MUL',
+    'DIV',
+    'MOD',
+    'JMP',
+    'JMZ',
+    'JMN',
+    'DJN',
+    'CMP',
+    'SLT',
+    'SPL',
+    'SEQ',
+    'SNE',
+    'NOP'
+  ],
+  preprocessor: ['EQU', 'END', 'ORG', 'FOR', 'ROF'],
+  addressingModes: ['#', '$', '@', '<', '>', '{', '}', '*'],
+  tokenizer: {
+    root: [
+      [
+        /[a-zA-Z_$][\w$]*/,
+        {
+          cases: {
+            '@opcodes': 'keyword',
+            '@preprocessor': 'keyword',
+            '@default': 'identifier'
+          }
+        }
+      ],
+
+      // meta
+      [/;(name|author|strategy).*$/, 'meta'],
+      [/;(redcode|redcode-.*)$/, 'meta'],
+      [/;assert .+$/, 'meta'],
+
+      // whitespace
+      { include: '@whitespace' },
+
+      // preprocessor maths <- THIS IS WRONG TROUbLE FINDING * (is it preprocessor?)
+      // [/(?<=equ.+)(\+|\-|\*|\/)/][
+      //   // delimiters
+      //   (/[:,.]/, 'delimiter')
+      // ],
+
+      // numbers
+      [/[0-9]+/, 'number'],
+
+      // addressing mode
+      [/(#|\$|@|<|>|{|}|\*)/, 'type']
+    ],
+    whitespace: [
+      [/[ \t\r\n]+/, 'white'],
+      [/;.*$/, 'comment']
+    ]
+  }
+}
+
+export const redcodeTheme = {
+  base: 'vs-dark',
+  inherit: true,
+  rules: [
+    // { token: 'custom-info', foreground: '808080' },
+    // { token: 'custom-error', foreground: 'ff0000', fontStyle: 'bold' },
+  ],
+  colors: {
+    'editor.background': '#353E4A',
+    'editor.lineHighlightBackground': '#20252C'
+  }
+}


### PR DESCRIPTION
This PR adds the monaco editor from this repo https://github.com/suren-atoyan/monaco-react and a specific theme for redcode to handle the styling. It uses the language definition thingy you sent me.

Syntax highlighting works (as far as the language def), as do line numbers and collapsing blocks.

There is an annoying visual quirk where it seems to have pushed a 2px space onto the bottom of the screen but it's OK for now to check out and play with.

![image](https://user-images.githubusercontent.com/1190042/89155548-f14aa880-d560-11ea-8e14-9097c152ac8d.png)


Future enhancement here may be:

- Creating a totally custom style for it - atm its tweaked vs-dark
- Add code completion stuff, not sure how to do this but it's do-able!

Resolves #15 
Resolves #19 from yesteryear!