### PR TITLE
Hook up core inspector

### DIFF
--- a/packages/corewar-app/src/App.js
+++ b/packages/corewar-app/src/App.js
@@ -1,6 +1,6 @@
 import React, { useEffect, useState } from 'react'
 import { useDispatch, useSelector } from 'react-redux'
-import { Switch, Route } from 'react-router-dom'
+import { Switch, Route, Redirect } from 'react-router-dom'
 import Header from './app-chrome/header'
 import Body from './app-chrome/body'
 import Tab from './app-chrome/tab'
@@ -57,7 +57,7 @@ function App({ location }) {
       <Body>
         <Switch location={isModal ? previousLocation : location}>
           <Route exact path="/">
-            <Editor />
+            <Redirect to="/editor" />
           </Route>
           <Route path="/editor">
             <Editor />

--- a/packages/corewar-app/src/app-chrome/body.js
+++ b/packages/corewar-app/src/app-chrome/body.js
@@ -1,7 +1,7 @@
 import React from 'react'
 
 const Body = ({ children }) => (
-  <section className="flex flex-auto justify-between bg-gray-800 border-gray-700 border rounded rounded-tl-none p-2 pt-4">
+  <section className="flex flex-auto justify-between bg-gray-800 border-gray-700 border rounded rounded-tl-none p-2">
     {children}
   </section>
 )

--- a/packages/corewar-app/src/features/files/code-editor.js
+++ b/packages/corewar-app/src/features/files/code-editor.js
@@ -35,7 +35,7 @@ const CodeEditor = ({ currentFile }) => {
   const changeHandler = (event, value) => throttle(dispatch(parse(value)), 500)
 
   return (
-    <section className="flex flex-col justify-between flex-initial w-full p-2 rounded-lg rounded-tl-none bg-gray-700 text-gray-100">
+    <section className="flex flex-col justify-start flex-initial w-full p-2 rounded-lg rounded-tl-none bg-gray-700 text-gray-100">
       <FileStatusBar />
       <ControlledEditor
         className="font-code"

--- a/packages/corewar-app/src/features/simulator/actions.js
+++ b/packages/corewar-app/src/features/simulator/actions.js
@@ -7,7 +7,7 @@ export const RUN = 'simulator/RUN'
 export const PAUSE = 'simulator/PAUSE'
 export const FINISH = 'simulator/FINISH'
 export const REPUBLISH = 'simulator/REPUBLISH'
-export const GET_CORE_INSTRUCTIONS = 'simulator/GET_CORE_INSTRUCTIONS'
+export const SET_CORE_INSTRUCTIONS = 'simulator/SET_CORE_INSTRUCTIONS'
 export const SET_PROCESS_RATE = 'simulator/SET_PROCESS_RATE'
 export const SET_CORE_OPTIONS = 'simulator/SET_CORE_OPTIONS'
 export const TOGGLE_SETTINGS = 'simulator/TOGGLE_SETTINGS'
@@ -18,7 +18,7 @@ export const STEP_REQUESTED = 'simulator/STEP_REQUESTED'
 export const RUN_REQUESTED = 'simulator/RUN_REQUESTED'
 export const FINISH_REQUESTED = 'simulator/FINISH_REQUESTED'
 export const REPUBLISH_REQUESTED = 'simulator/REPUBLISH_REQUESTED'
-export const GET_CORE_INSTRUCTIONS_REQUESTED = 'simulator/GET_CORE_INSTRUCTIONS_REQUESTED'
+export const SET_CORE_INSTRUCTIONS_REQUESTED = 'simulator/SET_CORE_INSTRUCTIONS_REQUESTED'
 export const SET_PROCESS_RATE_REQUESTED = 'simulator/SET_PROCESS_RATE_REQUESTED'
 export const SET_CORE_OPTIONS_REQUESTED = 'simulator/SET_CORE_OPTIONS_REQUESTED'
 
@@ -32,7 +32,7 @@ export const run = () => action(RUN_REQUESTED)
 export const pause = () => action(PAUSE)
 export const finish = () => action(FINISH_REQUESTED)
 export const republish = () => action(REPUBLISH_REQUESTED)
-export const getCoreInstructions = address => action(GET_CORE_INSTRUCTIONS_REQUESTED, { address })
+export const setCoreInstructions = address => action(SET_CORE_INSTRUCTIONS_REQUESTED, { address })
 export const setProcessRate = rate => action(SET_PROCESS_RATE_REQUESTED, { rate })
 export const setCoreOptions = id => action(SET_CORE_OPTIONS_REQUESTED, { id })
 export const toggleSettings = () => action(TOGGLE_SETTINGS)

--- a/packages/corewar-app/src/features/simulator/core-inspector.js
+++ b/packages/corewar-app/src/features/simulator/core-inspector.js
@@ -1,49 +1,44 @@
 import React from 'react'
+import { useSelector } from 'react-redux'
 import SectionHeader from '../../app-chrome/section-header'
-
-const data = [
-  {
-    address: 386,
-    instruction: 'MOV.I',
-    aOperand: '>1185',
-    bOperand: '$-1184'
-  },
-  {
-    address: 387,
-    instruction: 'MOV.I',
-    aOperand: '>1186',
-    bOperand: '$-1185'
-  }
-]
+import { getSimulatorState } from './reducer'
 
 const MemoryAddress = ({ command }) => (
   <tr className="font-code h-8">
     <td>{command.address}</td>
-    <td>{command.instruction}</td>
-    <td>{command.aOperand}</td>
-    <td>{command.bOperand}</td>
+    <td>{`${command.opcode}.${command.modifier}`}</td>
+    <td>{`${command.aOperand.mode}${command.aOperand.address}`}</td>
+    <td>{`${command.bOperand.mode}${command.bOperand.address}`}</td>
   </tr>
 )
 
-const CoreInspector = () => (
-  <div className="w-full flex flex-col flex-initial justify-start p-2 pb-0">
-    <SectionHeader>Core Inspector</SectionHeader>
-    <table className="text-sm text-right table-fixed mt-4">
-      <thead className="font-semibold text-xs h-12">
-        <tr>
-          <td className="break-all lg:w-16">Address</td>
-          <td className="break-all lg:w-20">Instruction</td>
-          <td className="break-all lg:w-24">A Operand</td>
-          <td className="break-all lg:w-24">B Operand</td>
-        </tr>
-      </thead>
-      <tbody>
-        {data.map(d => (
-          <MemoryAddress command={d} key={d.address} />
-        ))}
-      </tbody>
-    </table>
-  </div>
-)
+const CoreInspector = () => {
+  const { instructions, focus } = useSelector(getSimulatorState)
+
+  return (
+    <div className="w-full flex flex-col flex-initial justify-start p-2 pb-0">
+      <SectionHeader>Core Inspector</SectionHeader>
+      <table className="text-sm text-right table-fixed mt-4">
+        <thead className="font-semibold text-xs h-12">
+          <tr>
+            <td className="break-all lg:w-16">Address</td>
+            <td className="break-all lg:w-20">Instruction</td>
+            <td className="break-all lg:w-24">A Operand</td>
+            <td className="break-all lg:w-24">B Operand</td>
+          </tr>
+        </thead>
+        <tbody>
+          {instructions &&
+            instructions.map(instruction => (
+              <MemoryAddress
+                command={instruction.instruction}
+                key={instruction.instruction.address}
+              />
+            ))}
+        </tbody>
+      </table>
+    </div>
+  )
+}
 
 export default CoreInspector

--- a/packages/corewar-app/src/features/simulator/core-inspector.js
+++ b/packages/corewar-app/src/features/simulator/core-inspector.js
@@ -13,7 +13,7 @@ const MemoryAddress = ({ command }) => (
 )
 
 const CoreInspector = () => {
-  const { instructions, focus } = useSelector(getSimulatorState)
+  const { instructions } = useSelector(getSimulatorState)
 
   return (
     <div className="w-full flex flex-col flex-initial justify-start p-2 pb-0">

--- a/packages/corewar-app/src/features/simulator/core-inspector.js
+++ b/packages/corewar-app/src/features/simulator/core-inspector.js
@@ -26,7 +26,7 @@ const MemoryAddress = ({ command }) => (
 )
 
 const CoreInspector = () => (
-  <div className="h-core flex flex-col flex-initial bg-gray-700 rounded-lg p-4 pb-0">
+  <div className="w-full flex flex-col flex-initial justify-start p-2 pb-0">
     <SectionHeader>Core Inspector</SectionHeader>
     <table className="text-sm text-right table-fixed mt-4">
       <thead className="font-semibold text-xs h-12">

--- a/packages/corewar-app/src/features/simulator/core.js
+++ b/packages/corewar-app/src/features/simulator/core.js
@@ -26,6 +26,7 @@ const Core = () => {
   const cellsHigh = useRef(null)
 
   const cellSprite = useRef(null)
+  const endRowCellSprite = useRef(null)
 
   const messages = useRef([])
   const gridRendered = useRef([])
@@ -105,6 +106,7 @@ const Core = () => {
 
     // moved sprite code here as sprites need to be redone when dimensions change
     cellSprite.current = prerenderCell()
+    endRowCellSprite.current = prerenderRowEndCell()
     nextExecutionSprite.current = prerenderExecute('#D4DDE8')
 
     colours.forEach(c => {
@@ -140,6 +142,21 @@ const Core = () => {
     context.moveTo(0, cellSize.current)
     context.lineTo(0, 0)
     context.lineTo(cellSize.current, 0)
+    context.stroke()
+
+    return sprite
+  }
+
+  const prerenderRowEndCell = () => {
+    const sprite = buildSprite()
+
+    const context = sprite.context
+    context.strokeStyle = '#D4DDE8'
+    context.beginPath()
+    context.moveTo(0, cellSize.current)
+    context.lineTo(0, 0)
+    context.lineTo(cellSize.current, 0)
+    context.lineTo(cellSize.current, cellSize.current)
     context.stroke()
 
     return sprite
@@ -208,7 +225,14 @@ const Core = () => {
     let i = 0
     for (let y = 0; y < cellsHigh.current * cellSize.current; y += cellSize.current) {
       for (let x = 0; x < cellsWide.current * cellSize.current; x += cellSize.current) {
-        coreContext.current.drawImage(cellSprite.current.canvas, x, y)
+        let sprite
+        if (x / cellSize.current === cellsWide.current - 1) {
+          sprite = endRowCellSprite.current
+        } else {
+          sprite = cellSprite.current
+        }
+
+        coreContext.current.drawImage(sprite.canvas, x, y)
         if (++i >= coreSize) {
           gridRendered.current = true
           return
@@ -355,7 +379,7 @@ const Core = () => {
   return (
     <section className="flex flex-initial items-center justify-center">
       <div
-        className="relative max-w-core max-h-core min-w-96 min-h-96 lg:w-core lg:h-core bg-gray-500 rounded"
+        className="relative max-w-core max-h-core min-w-96 min-h-96 lg:w-core lg:h-core bg-gray-700 rounded mx-2"
         ref={canvasContainer}
       >
         <canvas

--- a/packages/corewar-app/src/features/simulator/core.js
+++ b/packages/corewar-app/src/features/simulator/core.js
@@ -377,9 +377,9 @@ const Core = () => {
   }
 
   return (
-    <section className="flex flex-initial items-center justify-center">
+    <section className="flex flex-initial items-start justify-center rounded rounded-tl-none rounded-tr-none border border-gray-700 border-t-0">
       <div
-        className="relative max-w-core max-h-core min-w-96 min-h-96 lg:w-core lg:h-core bg-gray-700 rounded mx-2"
+        className="relative max-w-core max-h-core min-w-96 min-h-96 lg:w-core lg:h-core"
         ref={canvasContainer}
       >
         <canvas

--- a/packages/corewar-app/src/features/simulator/core.js
+++ b/packages/corewar-app/src/features/simulator/core.js
@@ -1,12 +1,13 @@
 import React, { useState, useEffect, useLayoutEffect, useRef } from 'react'
-import { useSelector } from 'react-redux'
+import { useSelector, useDispatch } from 'react-redux'
 import * as PubSub from 'pubsub-js'
 import throttle from '../../services/throttle'
-import { getCoreInstructions, republish } from './actions'
+import { setCoreInstructions, republish } from './actions'
 import { getFileState } from '../files/reducer'
 import { getSimulatorState } from './reducer'
 
 const Core = () => {
+  const dispatch = useDispatch()
   const { colours } = useSelector(getFileState)
   const { coreSize, isInitialised } = useSelector(getSimulatorState)
 
@@ -68,14 +69,14 @@ const Core = () => {
     interactiveContext.current = interactiveCanvasEl.current.getContext('2d')
   }, [])
 
-  useLayoutEffect(() => {
+  useEffect(() => {
     interactiveCanvasEl.current.addEventListener('click', e => canvasClick(e))
 
     window.addEventListener(
       'resize',
       throttle(() => init(), 200)
     )
-  }, []) // eslint-disable-line react-hooks/exhaustive-deps
+  }, [isInitialised]) // eslint-disable-line react-hooks/exhaustive-deps
 
   useEffect(() => {
     calculateCoreDimensions()
@@ -351,17 +352,18 @@ const Core = () => {
   }
 
   const canvasClick = e => {
+    console.log('click', isInitialised)
     if (!isInitialised) {
       return
     }
-
+    console.log('initialised')
     const point = getRelativeCoordinates(e)
 
     const address = screenCoordinateToAddress(point)
 
     inspectionAddress.current = address
-
-    getCoreInstructions(address)
+    console.log('dispatch(getCoreInstructions(' + address + '))')
+    dispatch(setCoreInstructions(address))
   }
 
   const highlightClickPoint = () => {

--- a/packages/corewar-app/src/features/simulator/progress.js
+++ b/packages/corewar-app/src/features/simulator/progress.js
@@ -17,10 +17,10 @@ const Progress = () => {
           ></span>
         </div>
       )}
-      <div className="w-8 h-8 mx-2 flex items-center">
-        {roundResult.winnerData && `${roundResult.outcome} for`}
+      <div className="mx-2 flex items-center justify-center relative">
+        {roundResult.winnerData && `${roundResult.outcome} for `}
         {roundResult.winnerData && (
-          <div>
+          <div className="ml-2 h-24 flex items-center justify-center relative">
             <img
               src={`data:image/svg+xml;base64,${roundResult.winnerData.icon}`}
               alt={`${roundResult.winnerData.name} avatar`}

--- a/packages/corewar-app/src/features/simulator/progress.js
+++ b/packages/corewar-app/src/features/simulator/progress.js
@@ -1,69 +1,33 @@
-import React, { useRef, useEffect } from 'react'
+import React from 'react'
 import { useSelector } from 'react-redux'
-import * as PubSub from 'pubsub-js'
-import { getFileState } from '../files/reducer'
-import { replaceItem } from '../../services/array'
 import { getSimulatorState } from './reducer'
-
-const getWidth = (tasks, maxTasks) => {
-  if (!tasks) {
-    return 1
-  }
-
-  return Math.floor((tasks / maxTasks) * 100)
-}
+import SectionHeader from '../../app-chrome/section-header'
 
 const Progress = () => {
-  const { files } = useSelector(getFileState)
-  const { runProgress, maxTasks } = useSelector(getSimulatorState)
-  //const [tasks, setTasks] = useState([])
-  const tasks = useRef([])
-  useEffect(() => {
-    PubSub.subscribe('CORE_INITIALISE', (msg, data) => {
-      tasks.current = []
-    })
-    return function cleanup() {
-      PubSub.unsubscribe('CORE_INITIALISE')
-    }
-  }, [])
-  useEffect(() => {
-    PubSub.subscribe('TASK_COUNT', (msg, data) => {
-      let newTasks = tasks.current
-
-      data.forEach(item => {
-        newTasks = replaceItem(item.warriorId, newTasks, item.taskCount)
-      })
-
-      tasks.current = newTasks
-
-      return function cleanup() {
-        PubSub.unsubscribe('TASK_COUNT')
-      }
-    })
-  }, [])
+  const { runProgress, roundResult } = useSelector(getSimulatorState)
   return (
-    <div className="max-w-core w-full h-30 flex-initial">
-      <div className="h-8 flex items-center justify-center relative">
-        <span className="w-full h-8 flex justify-center items-center z-10 rounded border border-gray-700">{`${
-          runProgress ? Math.round(runProgress) : 0
-        }%`}</span>
-        <span
-          className="absolute left-0 bg-gray-700 h-8 rounded"
-          style={{ width: `${runProgress ? runProgress : 0}%` }}
-        ></span>
-      </div>
-      <div className="flex flex-col h-20 flex-initial">
-        {files.map((file, i) => (
-          <div
-            key={file.data.hash}
-            className={`mt-2 rounded h-${Math.round(16 / files.length)}`}
-            style={{
-              width: `${getWidth(tasks[i], maxTasks)}%`,
-              backgroundColor: `${file.data.icon &&
-                `rgba(${file.data.icon.foreground[0]},${file.data.icon.foreground[1]},${file.data.icon.foreground[2]},${file.data.icon.foreground[3]})`}`
-            }}
-          ></div>
-        ))}
+    <div className="max-w-core w-full h-30 flex-initial my-2 p-2">
+      <SectionHeader>Progress</SectionHeader>
+      {!roundResult.outcome && (
+        <div className="h-8 flex items-center justify-center relative">
+          <span className="w-full h-4 flex justify-center items-center z-10"></span>
+          <span
+            className="absolute left-0 bg-gray-700 h-4 rounded"
+            style={{ width: `${runProgress ? runProgress : 0}%` }}
+          ></span>
+        </div>
+      )}
+      <div className="w-8 h-8 mx-2 flex items-center">
+        {roundResult.winnerData && `${roundResult.outcome} for`}
+        {roundResult.winnerData && (
+          <div>
+            <img
+              src={`data:image/svg+xml;base64,${roundResult.winnerData.icon}`}
+              alt={`${roundResult.winnerData.name} avatar`}
+            />
+            <span className="flex-1 hover:underline">{roundResult.winnerData.name}</span>
+          </div>
+        )}
       </div>
     </div>
   )

--- a/packages/corewar-app/src/features/simulator/reducer.js
+++ b/packages/corewar-app/src/features/simulator/reducer.js
@@ -6,7 +6,7 @@ import {
   PAUSE,
   RUN_PROGRESS,
   RUN_ENDED,
-  GET_CORE_INSTRUCTIONS,
+  SET_CORE_INSTRUCTIONS,
   SET_CORE_FOCUS,
   SET_PROCESS_RATE,
   SET_CORE_OPTIONS,
@@ -68,10 +68,10 @@ export default (state = initialState, action) => {
         roundResult: action.data
       }
 
-    case GET_CORE_INSTRUCTIONS:
+    case SET_CORE_INSTRUCTIONS:
       return {
         ...state,
-        coreInfo: action.coreInfo
+        instructions: action.instructions
       }
 
     case SET_CORE_FOCUS:

--- a/packages/corewar-app/src/features/simulator/sagas.js
+++ b/packages/corewar-app/src/features/simulator/sagas.js
@@ -26,8 +26,8 @@ import {
   START_REQUESTED,
   REPUBLISH,
   REPUBLISH_REQUESTED,
-  GET_CORE_INSTRUCTIONS,
-  GET_CORE_INSTRUCTIONS_REQUESTED,
+  SET_CORE_INSTRUCTIONS,
+  SET_CORE_INSTRUCTIONS_REQUESTED,
   SET_CORE_FOCUS,
   SET_PROCESS_RATE,
   SET_PROCESS_RATE_REQUESTED,
@@ -64,15 +64,15 @@ function* stepSaga() {
 
   const lowerLimit = focus - 5
   const upperLimit = focus + 5
-  const coreInfo = []
+  const instructions = []
 
   for (let index = lowerLimit; index <= upperLimit; index++) {
     const info = yield call([corewar, corewar.getWithInfoAt], index)
     info.instruction.isCurrent = index === focus
-    coreInfo.push(info)
+    instructions.push(info)
   }
 
-  yield put({ type: GET_CORE_INSTRUCTIONS, coreInfo })
+  yield put({ type: SET_CORE_INSTRUCTIONS, instructions })
 }
 
 export function* runSaga() {
@@ -163,20 +163,24 @@ export function* finishSaga() {
   yield call([corewar, corewar.run])
 }
 
-function* getCoreInstructionsSaga({ address }) {
+function* setCoreInstructionsSaga({ address }) {
   const lowerLimit = address - 5
   const upperLimit = address + 5
-  const coreInfo = []
+  const instructions = []
+
+  console.log(address)
 
   for (let index = lowerLimit; index <= upperLimit; index++) {
     const info = yield call([corewar, corewar.getWithInfoAt], index)
     info.instruction.isCurrent = index === address
-    coreInfo.push(info)
+    instructions.push(info)
   }
 
   yield put({ type: SET_CORE_FOCUS, focus: address })
 
-  yield put({ type: GET_CORE_INSTRUCTIONS, coreInfo })
+  console.log(instructions)
+
+  yield put({ type: SET_CORE_INSTRUCTIONS, instructions })
 }
 
 function* setProcessRateSaga({ rate }) {
@@ -243,7 +247,7 @@ export const simulatorWatchers = [
   takeLatest(RUN_REQUESTED, runSaga),
   takeLatest(REPUBLISH_REQUESTED, republishSaga),
   takeLatest(SET_CORE_OPTIONS_REQUESTED, setCoreOptionsSaga),
-  takeLatest(GET_CORE_INSTRUCTIONS_REQUESTED, getCoreInstructionsSaga),
+  takeLatest(SET_CORE_INSTRUCTIONS_REQUESTED, setCoreInstructionsSaga),
   takeLatest(SET_PROCESS_RATE_REQUESTED, setProcessRateSaga),
   fork(watchRoundProgressChannel),
   fork(watchRoundEndChannel),

--- a/packages/corewar-app/src/features/simulator/simulator-controls.js
+++ b/packages/corewar-app/src/features/simulator/simulator-controls.js
@@ -26,7 +26,7 @@ const SimulatorControls = () => {
   const dispatch = useDispatch()
   const { isRunning, isInitialised } = useSelector(getSimulatorState)
   return (
-    <div className="max-w-core mb-2 flex justify-evenly items-center text-gray-100">
+    <div className="max-w-core flex justify-evenly items-center text-gray-100 h-24 mt-4 rounded rounded-br-none rounded-bl-none border border-gray-700 border-b-0">
       <SimulatorButton
         clickHandler={() => dispatch(run())}
         visible={!isRunning}

--- a/packages/corewar-app/src/features/simulator/simulator.js
+++ b/packages/corewar-app/src/features/simulator/simulator.js
@@ -1,13 +1,11 @@
 import React from 'react'
 import SimulatorControls from './simulator-controls'
 import Core from './core'
-import Progress from './progress'
 import SectionHeader from '../../app-chrome/section-header'
 
 const Simulator = () => (
-  <section className="max-w-core flex flex-col flex-initial justify-between">
+  <section className="max-w-core flex flex-col flex-initial justify-start mt-4">
     <SectionHeader>Simulator</SectionHeader>
-    <Progress></Progress>
     <SimulatorControls></SimulatorControls>
     <Core></Core>
   </section>

--- a/packages/corewar-app/src/features/simulator/tasks.js
+++ b/packages/corewar-app/src/features/simulator/tasks.js
@@ -1,0 +1,71 @@
+import React, { useEffect, useRef } from 'react'
+import { useSelector } from 'react-redux'
+import * as PubSub from 'pubsub-js'
+import { getFileState } from '../files/reducer'
+import { getSimulatorState } from './reducer'
+import { replaceItem } from '../../services/array'
+import SectionHeader from '../../app-chrome/section-header'
+
+const getWidth = (tasks, maxTasks) => {
+  if (!tasks) {
+    return 1
+  }
+  return Math.floor((tasks / maxTasks) * 100)
+}
+
+const Tasks = () => {
+  const { files } = useSelector(getFileState)
+  const { maxTasks } = useSelector(getSimulatorState)
+
+  const tasks = useRef([])
+
+  useEffect(() => {
+    PubSub.subscribe('CORE_INITIALISE', (msg, data) => {
+      tasks.current = []
+    })
+    return function cleanup() {
+      PubSub.unsubscribe('CORE_INITIALISE')
+    }
+  }, [])
+  useEffect(() => {
+    PubSub.subscribe('TASK_COUNT', (msg, data) => {
+      let newTasks = tasks.current
+
+      data.forEach(item => {
+        newTasks = replaceItem(item.warriorId, newTasks, item.taskCount)
+      })
+
+      tasks.current = newTasks
+
+      return function cleanup() {
+        PubSub.unsubscribe('TASK_COUNT')
+      }
+    })
+  }, [])
+
+  return (
+    <div className="flex flex-col my-2 h-24 p-2 flex-initial justify-start">
+      <SectionHeader>Tasks</SectionHeader>
+      {files
+        .filter(
+          file =>
+            !file.data.hasErrors &&
+            file.data.loaded &&
+            file.tokens.filter(y => y.category === 'OPCODE').length > 0
+        )
+        .map((file, i) => (
+          <div
+            key={file.data.hash}
+            className={`rounded my-1 h-${Math.round(16 / files.length)}`}
+            style={{
+              width: `${getWidth(tasks.current[i], maxTasks)}%`,
+              backgroundColor: `${file.data.icon &&
+                `rgba(${file.data.icon.foreground[0]},${file.data.icon.foreground[1]},${file.data.icon.foreground[2]},${file.data.icon.foreground[3]})`}`
+            }}
+          ></div>
+        ))}
+    </div>
+  )
+}
+
+export default Tasks

--- a/packages/corewar-app/src/pages/editor.js
+++ b/packages/corewar-app/src/pages/editor.js
@@ -2,17 +2,21 @@ import React from 'react'
 import FileManager from '../features/files/file-manager'
 import CoreInspector from '../features/simulator/core-inspector'
 import Simulator from '../features/simulator/simulator'
+import Tasks from '../features/simulator/tasks'
+import Progress from '../features/simulator/progress'
 
 const Editor = () => (
   <>
-    <section className="w-2/5 lg:w-1/2 flex flex-col">
+    <section className="w-1/2 lg:w-2/5 flex flex-col">
       <FileManager></FileManager>
     </section>
-    <section className="w-1/2 flex flex-row flex-initial justify-end">
-      <section className="hidden lg:flex flex-col flex-initial justify-end pr-2">
+    <section className="w-1/2 lg:w-3/5 flex flex-row flex-initial justify-between">
+      <Simulator></Simulator>
+      <section className="hidden lg:flex flex-col flex-initial justify-start w-full ml-8">
+        <Progress />
+        <Tasks />
         <CoreInspector></CoreInspector>
       </section>
-      <Simulator></Simulator>
     </section>
   </>
 )

--- a/packages/corewar-app/tailwind.config.js
+++ b/packages/corewar-app/tailwind.config.js
@@ -28,13 +28,13 @@ module.exports = {
         }
       },
       maxWidth: {
-        core: '37.5rem'
+        core: '42.5rem'
       },
       minWidth: {
         '96': '24rem'
       },
       maxHeight: {
-        core: '37.5rem'
+        core: '42.5rem'
       },
       minHeight: {
         '16': '4rem',
@@ -45,7 +45,7 @@ module.exports = {
         '84': '21rem',
         '96': '24rem',
         '128': '32rem',
-        core: '37.5rem'
+        core: '42.5rem'
       }
     }
   },


### PR DESCRIPTION
This PR adds the ability to click on an initialised core and see a simple representation of the core +/- 5 addresses from the selected location.

Needs a bit of a cleanup, tests, visual re-design, but it works!