### PR TITLE
Fix cell highlighting in core inspector

### DIFF
--- a/packages/corewar-app/src/features/simulator/core.js
+++ b/packages/corewar-app/src/features/simulator/core.js
@@ -35,6 +35,7 @@ const Core = () => {
   const sprites = useRef([])
   const nextExecutionSprite = useRef(null)
   const inspectionAddress = useRef(null)
+  const prevInspectionAddress = useRef(null)
 
   useEffect(() => {
     PubSub.subscribe('CORE_ACCESS', (msg, data) => {
@@ -361,6 +362,7 @@ const Core = () => {
 
     const address = screenCoordinateToAddress(point)
 
+    prevInspectionAddress.current = inspectionAddress.current
     inspectionAddress.current = address
     console.log('dispatch(getCoreInstructions(' + address + '))')
     dispatch(setCoreInstructions(address))
@@ -368,8 +370,12 @@ const Core = () => {
 
   const highlightClickPoint = () => {
     const address = inspectionAddress.current
+    const prevAddress = prevInspectionAddress.current
 
     const cell = addressToScreenCoordinate(address)
+    const prevCell = addressToScreenCoordinate(prevAddress)
+
+    interactiveContext.current.clearRect(prevCell.x-1, prevCell.y-1, cellSize.current+2, cellSize.current+2)
 
     const { x, y } = cell
 


### PR DESCRIPTION
On the master branch, the cell highlights don't disappear, so the core looks like this after a few clicks:
![image](https://user-images.githubusercontent.com/5091372/188202399-dcf5b095-f3bb-4c73-8a54-82c5f699d3eb.png)

I've corrected it so that the highlights clear properly 
![image](https://user-images.githubusercontent.com/5091372/188202222-73a1a95f-a70f-45a5-a349-682d4258f49a.png)
