### PR TITLE
Highlight focused address in inspector

### DIFF
--- a/packages/corewar-app/src/features/simulator/core-inspector.js
+++ b/packages/corewar-app/src/features/simulator/core-inspector.js
@@ -3,8 +3,8 @@ import { useSelector } from 'react-redux'
 import SectionHeader from '../../app-chrome/section-header'
 import { getSimulatorState } from './reducer'
 
-const MemoryAddress = ({ command }) => (
-  <tr className="font-code h-8">
+const MemoryAddress = ({ command, index }) => (
+  <tr className={`font-code h-8 ${index === 5 ? 'border' : ''}`}>
     <td>{command.address}</td>
     <td>{`${command.opcode}.${command.modifier}`}</td>
     <td>{`${command.aOperand.mode}${command.aOperand.address}`}</td>
@@ -29,10 +29,11 @@ const CoreInspector = () => {
         </thead>
         <tbody>
           {instructions &&
-            instructions.map(instruction => (
+            instructions.map((instruction, i) => (
               <MemoryAddress
                 command={instruction.instruction}
                 key={instruction.instruction.address}
+                index={i}
               />
             ))}
         </tbody>


### PR DESCRIPTION
Puts a border around the middle instruction in the inspector to make it clear which one is focused

![image](https://user-images.githubusercontent.com/5091372/188255591-4fd5e757-92ec-4008-9638-0a650edaab39.png)
